### PR TITLE
Added method to specify local storage name for caching

### DIFF
--- a/src/com/cloudinary/Url.java
+++ b/src/com/cloudinary/Url.java
@@ -23,6 +23,7 @@ public class Url {
 	private final Configuration config;
 	String publicId = null;
 	String type = null;
+        String cacheName = null;
 	String resourceType = null;
 	String format = null;
 	String version = null;
@@ -118,6 +119,17 @@ public class Url {
 
 	public Url type(String type) {
 		this.type = type;
+		return this;
+	}
+
+       
+        /**
+         * Local storage name to save image to, the url would be used as filename if this is not set
+         * @param cacheName
+         * @return
+         */
+	public Url cacheName(String cacheName) {
+		this.cacheName = cacheName;
 		return this;
 	}
 
@@ -677,6 +689,10 @@ public class Url {
             t.width(placeholder.getWidth());
             t.height(placeholder.getHeight());
             String url = generate(source);
-            return URLImage.createToStorage(placeholder, url, url, null);
+            String cache = this.cacheName;
+            if (cache == null) {
+                cache = url;
+            }
+            return URLImage.createToStorage(placeholder, cache, url, null);
         }
 }


### PR DESCRIPTION
If no filename provided, the url would be used. This is to allow downloading an image multiple times into different files. 

Usage example is creating a thumb and the hero from the same image.
